### PR TITLE
Fix macOS port issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ npm run start
 
 You should see a confirmation message like this:
 
-![Screenshot of a terminal, showing a server running at http://localhost:5000](./docs/terminal-example.png)
+![Screenshot of a terminal, showing a server running at http://localhost:9000](./docs/terminal-example.png)
 
-You can visit `http://localhost:5000` to view the page. You should see a bunch of unstyled content:
+You can visit `http://localhost:9000` to view the page. You should see a bunch of unstyled content:
 
 ![Screenshot of an unstyled page with a couple headings and some paragraphs](./docs/initial.png)
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "author": "Joshua Comeau",
   "scripts": {
-    "start": "live-server --port=5000 --host=localhost ."
+    "start": "live-server --port=9000 --host=localhost ."
   },
   "dependencies": {
     "live-server": "1.2.1"


### PR DESCRIPTION
Change port 5000->9000

Because macOS now uses port 5000 for _AirPlay Receiver_.

https://anandtripathi5.medium.com/port-5000-already-in-use-macos-monterey-issue-d86b02edd36c
